### PR TITLE
reset files variable before use

### DIFF
--- a/rmtrash
+++ b/rmtrash
@@ -588,6 +588,8 @@ if [ ! -h "$ARGUMENT" ] && [ ! -e "$ARGUMENT" ]; then
 	exit 256
 fi
 
+FILES=()
+
 # recursive mode
 if [ $RECURSIVE == true ]; then
 	# only delete on this filesystem


### PR DESCRIPTION
this way if the user was using $FILES for something
else it doesn't interfere with rmtrash
